### PR TITLE
Fix bug in `+.ggplot()`

### DIFF
--- a/R/manynet-utils.R
+++ b/R/manynet-utils.R
@@ -42,8 +42,12 @@ thisRequiresBio <- function(pkgname) {
 
 #' @export
 `+.ggplot` <- function(e1, e2, ...) {
-  thisRequires("patchwork")
-  patchwork::wrap_plots(e1, e2, ...)
+  if (inherits(e2, c("ggplot", "ggplot2::ggplot"))) {
+    thisRequires("patchwork")
+    patchwork::wrap_plots(e1, e2, ...)
+  } else {
+    NextMethod()
+  }
 }
 
 seq_nodes <- function(.data){


### PR DESCRIPTION
# Description

Hi there,

Apologies for not adhering to your checklist.
We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We found some cases where `+.ggplot` was invoked and one of the components was a `theme`, and this would incorrectly be forwarded to `patchwork::wrap_plot()`. This PR fixes that issue.

In addition, there were some other issues I couldn't quite place, so I recommend checking against the development version of ggplot2 yourself too.
You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun

# Checklist:

- PR form
  - [ ] Description above itemizes changes under subtitles, e.g. "## Data""
  - [ ] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [ ] Package builds on my OS without issues
- PR checks all pass for latest commit
  - [ ] CodeFactor check: Package improves or maintains good style
  - [ ] Package builds on Mac
  - [ ] Package builds on Windows
  - [ ] Package builds on Linux
  - [ ] CodeCov check: Package improves or maintains good test coverage
- Documentation
  - [ ] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [ ] Longer functions are commented inline or broken down into helper functions so that it is easier to debug in the future
  - [ ] PR description above and the NEWS.md file are aligned
  - [ ] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
